### PR TITLE
Module SW Version now includes Underscores 

### DIFF
--- a/rscpguiframe.py
+++ b/rscpguiframe.py
@@ -773,7 +773,7 @@ class RSCPGuiFrame(MainFrame, RSCPGuiMain):
             self.gSoftwaremodules.DeleteRows(0, self.gSoftwaremodules.GetNumberRows())
             self.gSoftwaremodules.AppendRows(len(d['INFO_MODULES_SW_VERSIONS']))
             row = 0
-            regex = r"([\d\.]*) \[(.*)\] \(SVN: *([\da-zA-Z]*)\)"
+            regex = r"([\d\.]*) \[(.*)\] \(SVN: *([\da-zA-Z0-9_\-]*)\)"
 
             for moduleversion in d['INFO_MODULES_SW_VERSIONS']:
                 module = moduleversion['INFO_MODULE'].data


### PR DESCRIPTION
Der Fehler `list index out of range` tritt auf, wenn `re.findall` keine Übereinstimmungen findet und daher eine leere Liste zurückgibt. Wenn Sie dann versuchen, mit `[0]` auf das erste Element der Liste zuzugreifen, führt dies zu diesem Fehler.

### Mögliche Ursachen:
1. **Regex passt nicht zur Eingabe**: Das Muster in `regex` stimmt nicht mit dem Format von `versiondata` überein.
2. **Unterschiedliche Datenstruktur**: Der String `versiondata` enthält möglicherweise unerwartete Zeichen oder ein anderes Format.

### Analyse des Codes:
Ihr Regex lautet:
```python
r"([\d\.]*) \[(.*)\] \(SVN: *([\da-zA-Z]*)\)"
```
Und `versiondata` ist:
```python
'2.0.60 [Mar 12 2025 13:04:13] (SVN:2025_02-rc2-10-g1b64f055b5)'
```

#### Problem:
- Der letzte Teil des Regex `([\da-zA-Z]*)` erwartet nur alphanumerische Zeichen (`\da-zA-Z`), aber in `versiondata` enthält der SVN-Teil (`2025_02-rc2-10-g1b64f055b5`) auch Unterstriche (`_`) und Bindestriche (`-`), die nicht im Regex berücksichtigt werden.

### Lösung:
Passen Sie das Regex an, um auch Unterstriche und Bindestriche zu erlauben:
```python
regex = r"([\d\.]*) \[(.*)\] \(SVN: *([\da-zA-Z0-9_\-]*)\)"
```


### Ausgabe:
Mit dem angepassten Regex sollte der Code nun korrekt funktionieren und Folgendes ausgeben:
```plaintext
('2.0.60', 'Mar 12 2025 13:04:13', '2025_02-rc2-10-g1b64f055b5')
```